### PR TITLE
Improvement for Heterogeneity Models on Parsing Rules (1.2 to 1.4x), plus hdlmm bug fixes

### DIFF
--- a/R/dlmtree.R
+++ b/R/dlmtree.R
@@ -943,87 +943,63 @@ dlmtree <- function(formula,
     modNames    <- names(model$Mo)                     
     splitRules  <- strsplit(model$termRules, "&", TRUE)
 
-    rule <- sapply(splitRules, function(str) {
-              paste0(lapply(sort(str), function(rule) {
-                # no rule
-                if (length(rule) == 0) {
-                  return("")
-                # *** Continuous ***
-                # >=
-                } else if (length(spl <- strsplit(rule, ">=", TRUE)[[1]]) == 2) {
-                  return(paste0("mod[['", modNames[as.numeric(spl[1]) + 1], "']] >= ",
-                                model$modSplitValRef[[as.numeric(spl[1]) + 1]][
-                                  as.numeric(spl[2]) + 1]))
-                # >
-                } else if (length(spl <- strsplit(rule, "<", TRUE)[[1]]) == 2) {
-                  return(paste0("mod[['", modNames[as.numeric(spl[1]) + 1], "']] < ",
-                                model$modSplitValRef[[as.numeric(spl[1]) + 1]][
-                                  as.numeric(spl[2]) + 1]))
-                # *** Categorical ***
-                # in
-                } else if (length(spl <- strsplit(rule, "[]", TRUE)[[1]]) == 2) {
-                  inList <- paste0("c('", paste0(model$modSplitValRef[[
-                    as.numeric(spl[1]) + 1]][
-                      eval(parse(text = paste0("c(", spl[2], ")"))) + 1
-                    ], collapse = "','"), "')")
-                  return(paste0("mod[['", modNames[as.numeric(spl[1]) + 1],
-                                "']] %in% ", inList))
-                # not in
-                } else if (length(spl <- strsplit(rule, "][", TRUE)[[1]]) == 2) {
-                  inList <- paste0("c('", paste0(model$modSplitValRef[[
-                    as.numeric(spl[1]) + 1]][
-                      eval(parse(text = paste0("c(", spl[2], ")"))) + 1
-                    ], collapse = "','"), "')")
-                  return(paste0("mod[['", modNames[as.numeric(spl[1]) + 1],
-                                "']] %notin% ", inList))
-                } else {
-                  return("")
-                }
-              }), collapse = " & ")})
+    # Parse only distinct rule strings, then expand by lookup.
+    # The same rule is pushed once per DLM term in the C++ recording loop,
+    # so termRules typically holds ~100x more entries than distinct rules
+    parseRuleStr <- function(str) {
+      paste0(lapply(sort(str), function(rule) {
+        # no rule
+        if (length(rule) == 0) {
+          return("")
+        # *** Continuous ***
+        # >=
+        } else if (length(spl <- strsplit(rule, ">=", TRUE)[[1]]) == 2) {
+          return(paste0("mod[['", modNames[as.numeric(spl[1]) + 1], "']] >= ",
+                        model$modSplitValRef[[as.numeric(spl[1]) + 1]][
+                          as.numeric(spl[2]) + 1]))
+        # >
+        } else if (length(spl <- strsplit(rule, "<", TRUE)[[1]]) == 2) {
+          return(paste0("mod[['", modNames[as.numeric(spl[1]) + 1], "']] < ",
+                        model$modSplitValRef[[as.numeric(spl[1]) + 1]][
+                          as.numeric(spl[2]) + 1]))
+        # *** Categorical ***
+        # in
+        } else if (length(spl <- strsplit(rule, "[]", TRUE)[[1]]) == 2) {
+          inList <- paste0("c('", paste0(model$modSplitValRef[[
+            as.numeric(spl[1]) + 1]][
+              eval(parse(text = paste0("c(", spl[2], ")"))) + 1
+            ], collapse = "','"), "')")
+          return(paste0("mod[['", modNames[as.numeric(spl[1]) + 1],
+                        "']] %in% ", inList))
+        # not in
+        } else if (length(spl <- strsplit(rule, "][", TRUE)[[1]]) == 2) {
+          inList <- paste0("c('", paste0(model$modSplitValRef[[
+            as.numeric(spl[1]) + 1]][
+              eval(parse(text = paste0("c(", spl[2], ")"))) + 1
+            ], collapse = "','"), "')")
+          return(paste0("mod[['", modNames[as.numeric(spl[1]) + 1],
+                        "']] %notin% ", inList))
+        } else {
+          return("")
+        }
+      }), collapse = " & ")
+    }
+
+    # Main effect rules
+    uniqueRuleStr <- unique(model$termRules)
+    uniqueParsed  <- as.character(sapply(strsplit(uniqueRuleStr, "&", TRUE),
+                                         parseRuleStr))
+    rule <- uniqueParsed[match(model$termRules, uniqueRuleStr)]
 
     # Mixture interaction for hdlmm
     if (model$class == "hdlmm" & model$interaction > 0) {
-      splitRulesMIX <- strsplit(model$termRuleMIX, "&", TRUE) 
-      ruleMIX <- as.character(sapply(splitRulesMIX, function(str) {
-                  paste0(lapply(sort(str), function(rule) {
-                    # no rule
-                    if (length(rule) == 0) {
-                      return("")
-                    # *** Continuous ***
-                    # >=
-                    } else if (length(spl <- strsplit(rule, ">=", TRUE)[[1]]) == 2) {
-                      return(paste0("mod[['", modNames[as.numeric(spl[1]) + 1], "']] >= ",
-                                    model$modSplitValRef[[as.numeric(spl[1]) + 1]][
-                                      as.numeric(spl[2]) + 1]))
-                    # >
-                    } else if (length(spl <- strsplit(rule, "<", TRUE)[[1]]) == 2) {
-                      return(paste0("mod[['", modNames[as.numeric(spl[1]) + 1], "']] < ",
-                                    model$modSplitValRef[[as.numeric(spl[1]) + 1]][
-                                      as.numeric(spl[2]) + 1]))
-                    # *** Categorical ***
-                    # in
-                    } else if (length(spl <- strsplit(rule, "[]", TRUE)[[1]]) == 2) {
-                      inList <- paste0("c('", paste0(model$modSplitValRef[[
-                        as.numeric(spl[1]) + 1]][
-                          eval(parse(text = paste0("c(", spl[2], ")"))) + 1
-                        ], collapse = "','"), "')")
-                      return(paste0("mod[['", modNames[as.numeric(spl[1]) + 1],
-                                    "']] %in% ", inList))
-                    # not in
-                    } else if (length(spl <- strsplit(rule, "][", TRUE)[[1]]) == 2) {
-                      inList <- paste0("c('", paste0(model$modSplitValRef[[
-                        as.numeric(spl[1]) + 1]][
-                          eval(parse(text = paste0("c(", spl[2], ")"))) + 1
-                        ], collapse = "','"), "')")
-                      return(paste0("mod[['", modNames[as.numeric(spl[1]) + 1],
-                                    "']] %notin% ", inList))
-                    } else {
-                      return("")
-                    }
-                  }), collapse = " & ")}))
-        } else {
-          ruleMIX = NA
-        }
+      uniqueRuleStrMIX <- unique(model$termRuleMIX)
+      uniqueParsedMIX  <- as.character(sapply(strsplit(uniqueRuleStrMIX, "&", TRUE),
+                                              parseRuleStr))
+      ruleMIX <- as.character(uniqueParsedMIX[match(model$termRuleMIX, uniqueRuleStrMIX)])
+    } else {
+      ruleMIX = NA
+    }
         
     model$modPairs <- sort(table(do.call(c, lapply(splitRules, function(r) {
       if (length(r) == 0) {

--- a/R/dlmtree.R
+++ b/R/dlmtree.R
@@ -984,46 +984,46 @@ dlmtree <- function(formula,
     # Mixture interaction for hdlmm
     if (model$class == "hdlmm" & model$interaction > 0) {
       splitRulesMIX <- strsplit(model$termRuleMIX, "&", TRUE) 
-      ruleMIX <- sapply(splitRulesMIX, function(str) {
-                paste0(lapply(sort(str), function(rule) {
-                  # no rule
-                  if (length(rule) == 0) {
-                    return("")
-                  # *** Continuous ***
-                  # >=
-                  } else if (length(spl <- strsplit(rule, ">=", TRUE)[[1]]) == 2) {
-                    return(paste0("mod[['", modNames[as.numeric(spl[1]) + 1], "']] >= ",
-                                  model$modSplitValRef[[as.numeric(spl[1]) + 1]][
-                                    as.numeric(spl[2]) + 1]))
-                  # >
-                  } else if (length(spl <- strsplit(rule, "<", TRUE)[[1]]) == 2) {
-                    return(paste0("mod[['", modNames[as.numeric(spl[1]) + 1], "']] < ",
-                                  model$modSplitValRef[[as.numeric(spl[1]) + 1]][
-                                    as.numeric(spl[2]) + 1]))
-                  # *** Categorical ***
-                  # in
-                  } else if (length(spl <- strsplit(rule, "[]", TRUE)[[1]]) == 2) {
-                    inList <- paste0("c('", paste0(model$modSplitValRef[[
-                      as.numeric(spl[1]) + 1]][
-                        eval(parse(text = paste0("c(", spl[2], ")"))) + 1
-                      ], collapse = "','"), "')")
-                    return(paste0("mod[['", modNames[as.numeric(spl[1]) + 1],
-                                  "']] %in% ", inList))
-                  # not in
-                  } else if (length(spl <- strsplit(rule, "][", TRUE)[[1]]) == 2) {
-                    inList <- paste0("c('", paste0(model$modSplitValRef[[
-                      as.numeric(spl[1]) + 1]][
-                        eval(parse(text = paste0("c(", spl[2], ")"))) + 1
-                      ], collapse = "','"), "')")
-                    return(paste0("mod[['", modNames[as.numeric(spl[1]) + 1],
-                                  "']] %notin% ", inList))
-                  } else {
-                    return("")
-                  }
-                }), collapse = " & ")})
-    } else {
-      ruleMIX = NA
-    }
+      ruleMIX <- as.character(sapply(splitRulesMIX, function(str) {
+                  paste0(lapply(sort(str), function(rule) {
+                    # no rule
+                    if (length(rule) == 0) {
+                      return("")
+                    # *** Continuous ***
+                    # >=
+                    } else if (length(spl <- strsplit(rule, ">=", TRUE)[[1]]) == 2) {
+                      return(paste0("mod[['", modNames[as.numeric(spl[1]) + 1], "']] >= ",
+                                    model$modSplitValRef[[as.numeric(spl[1]) + 1]][
+                                      as.numeric(spl[2]) + 1]))
+                    # >
+                    } else if (length(spl <- strsplit(rule, "<", TRUE)[[1]]) == 2) {
+                      return(paste0("mod[['", modNames[as.numeric(spl[1]) + 1], "']] < ",
+                                    model$modSplitValRef[[as.numeric(spl[1]) + 1]][
+                                      as.numeric(spl[2]) + 1]))
+                    # *** Categorical ***
+                    # in
+                    } else if (length(spl <- strsplit(rule, "[]", TRUE)[[1]]) == 2) {
+                      inList <- paste0("c('", paste0(model$modSplitValRef[[
+                        as.numeric(spl[1]) + 1]][
+                          eval(parse(text = paste0("c(", spl[2], ")"))) + 1
+                        ], collapse = "','"), "')")
+                      return(paste0("mod[['", modNames[as.numeric(spl[1]) + 1],
+                                    "']] %in% ", inList))
+                    # not in
+                    } else if (length(spl <- strsplit(rule, "][", TRUE)[[1]]) == 2) {
+                      inList <- paste0("c('", paste0(model$modSplitValRef[[
+                        as.numeric(spl[1]) + 1]][
+                          eval(parse(text = paste0("c(", spl[2], ")"))) + 1
+                        ], collapse = "','"), "')")
+                      return(paste0("mod[['", modNames[as.numeric(spl[1]) + 1],
+                                    "']] %notin% ", inList))
+                    } else {
+                      return("")
+                    }
+                  }), collapse = " & ")}))
+        } else {
+          ruleMIX = NA
+        }
         
     model$modPairs <- sort(table(do.call(c, lapply(splitRules, function(r) {
       if (length(r) == 0) {
@@ -1043,12 +1043,35 @@ dlmtree <- function(formula,
 
     # *** Combine the rules and the exposure data frames for HDLM, HDLMM ***
     if (model$class == "hdlmm") {
+    # Combine DLM with rules with colnames
+      log_line <- sprintf(
+        "dim(TreeStructs)=%dx%d  length(rule)=%d  class(rule)=%s  interaction=%s\n",
+        nrow(model$TreeStructs), ncol(model$TreeStructs),
+        length(rule), class(rule), model$interaction
+      )
+      cat(log_line, file = "/Users/seongwonim/Desktop/dlmtree-dev/debug_log.txt", append = TRUE)
+
       # Combine DLM with rules with colnames
-      model$TreeStructs           <- cbind.data.frame(rule, model$TreeStructs)
+      combined <- cbind.data.frame(rule, model$TreeStructs)
+      cat(sprintf("AFTER cbind: dim=%dx%d  class=%s\n",
+                  nrow(combined), ncol(combined), paste(class(combined), collapse=",")),
+          file = "/Users/seongwonim/Desktop/dlmtree-dev/debug_log.txt", append = TRUE)
+      cat(sprintf("BEFORE cbind: TreeStructs class=%s\n", paste(class(model$TreeStructs), collapse=",")),
+          file = "/Users/seongwonim/Desktop/dlmtree-dev/debug_log.txt", append = TRUE)
+      model$TreeStructs           <- combined
       colnames(model$TreeStructs) <- c("Rule", "Iter", "Tree", "Mod", "dlmPair", "dlmTerm", "exp", "tmin", "tmax", "est", "kappa")
+
+      cat(sprintf("TreeStructs colnames SUCCEEDED, ncol=%d\n", ncol(model$TreeStructs)),
+      file = "/Users/seongwonim/Desktop/dlmtree-dev/debug_log.txt", append = TRUE)
       
       # Default of model$MIX is a vector of zeros
       if (model$interaction != 0) {
+        log_line2 <- sprintf(
+          "MIX before cbind: nrow=%d ncol=%d  ruleMIX length=%d class=%s  termRuleMIX length=%d\n",
+          nrow(model$MIX), ncol(model$MIX), length(ruleMIX), class(ruleMIX), length(model$termRuleMIX)
+        )
+        cat(log_line2, file = "/Users/seongwonim/Desktop/dlmtree-dev/debug_log.txt", append = TRUE)
+
         model$MIX           <- as.data.frame(model$MIX)
         model$MIX           <- cbind.data.frame(ruleMIX, model$MIX)
         colnames(model$MIX) <- c("Rule", "Iter", "Tree", "Mod", "exp1", "tmin1", "tmax1", "exp2", "tmin2", "tmax2", "est")

--- a/R/dlmtree.R
+++ b/R/dlmtree.R
@@ -1044,34 +1044,11 @@ dlmtree <- function(formula,
     # *** Combine the rules and the exposure data frames for HDLM, HDLMM ***
     if (model$class == "hdlmm") {
     # Combine DLM with rules with colnames
-      log_line <- sprintf(
-        "dim(TreeStructs)=%dx%d  length(rule)=%d  class(rule)=%s  interaction=%s\n",
-        nrow(model$TreeStructs), ncol(model$TreeStructs),
-        length(rule), class(rule), model$interaction
-      )
-      cat(log_line, file = "/Users/seongwonim/Desktop/dlmtree-dev/debug_log.txt", append = TRUE)
-
-      # Combine DLM with rules with colnames
-      combined <- cbind.data.frame(rule, model$TreeStructs)
-      cat(sprintf("AFTER cbind: dim=%dx%d  class=%s\n",
-                  nrow(combined), ncol(combined), paste(class(combined), collapse=",")),
-          file = "/Users/seongwonim/Desktop/dlmtree-dev/debug_log.txt", append = TRUE)
-      cat(sprintf("BEFORE cbind: TreeStructs class=%s\n", paste(class(model$TreeStructs), collapse=",")),
-          file = "/Users/seongwonim/Desktop/dlmtree-dev/debug_log.txt", append = TRUE)
-      model$TreeStructs           <- combined
+      model$TreeStructs           <- cbind.data.frame(rule, model$TreeStructs)
       colnames(model$TreeStructs) <- c("Rule", "Iter", "Tree", "Mod", "dlmPair", "dlmTerm", "exp", "tmin", "tmax", "est", "kappa")
-
-      cat(sprintf("TreeStructs colnames SUCCEEDED, ncol=%d\n", ncol(model$TreeStructs)),
-      file = "/Users/seongwonim/Desktop/dlmtree-dev/debug_log.txt", append = TRUE)
       
       # Default of model$MIX is a vector of zeros
       if (model$interaction != 0) {
-        log_line2 <- sprintf(
-          "MIX before cbind: nrow=%d ncol=%d  ruleMIX length=%d class=%s  termRuleMIX length=%d\n",
-          nrow(model$MIX), ncol(model$MIX), length(ruleMIX), class(ruleMIX), length(model$termRuleMIX)
-        )
-        cat(log_line2, file = "/Users/seongwonim/Desktop/dlmtree-dev/debug_log.txt", append = TRUE)
-
         model$MIX           <- as.data.frame(model$MIX)
         model$MIX           <- cbind.data.frame(ruleMIX, model$MIX)
         colnames(model$MIX) <- c("Rule", "Iter", "Tree", "Mod", "exp1", "tmin1", "tmax1", "exp2", "tmin2", "tmax2", "est")

--- a/src/dlmtreeMixtures.cpp
+++ b/src/dlmtreeMixtures.cpp
@@ -195,6 +195,13 @@ Rcpp::List dlmtreeMixtures(const Rcpp::List model){
 
   // *** Logs ***
   dlmtreeLog *dgn = new dlmtreeLog();
+
+  // Pre-allocate: sizes are known up front, avoiding repeated
+  // reallocation and copying of Eigen objects during the run.
+  std::size_t nTreeUpdates = (std::size_t)(ctr->iter + ctr->burn) * ctr->nTrees;
+  (dgn->treeDLMAccept).reserve(nTreeUpdates * 2);  // two dlm trees per tree pair
+  (dgn->treeModAccept).reserve(nTreeUpdates);
+
   (dgn->gamma).resize(ctr->pZ, ctr->nRec);    (dgn->gamma).setZero();  
   (dgn->sigma2).resize(ctr->nRec);            (dgn->sigma2).setZero(); 
   (dgn->nu).resize(ctr->nRec);                (dgn->nu).setZero();     
@@ -924,7 +931,7 @@ void dlmtreeMixtures_TreeMCMC(int t, NodeStruct* expNS, Node* modTree,
   for (Node* nt : newDlmTerm1) {          // Go through the new terminal node
     Exp[newExp]->updateNodeVals(nt);      // Update the calculations
   }
-  
+
   // MH ratio
   modTree->setUpdateXmat(1);
 
@@ -1028,8 +1035,6 @@ void dlmtreeMixtures_TreeMCMC(int t, NodeStruct* expNS, Node* modTree,
   for (Node* nt : newDlmTerm2) {          // Go through the new terminal node
     Exp[newExp]->updateNodeVals(nt);      // Update the calculations
   }
-
-
   
   // MH ratio
   modTree->setUpdateXmat(1);
@@ -1441,7 +1446,9 @@ treeMHR dlmtreeMixtures_MHR(std::vector<Node*> modTerm,
 
   // Create block matrices corresponding to modifier nodes
   int start = 0;
+
   for (Node* n : modTerm) { 
+
     // Retrieve indices subset by the modifier tree
     Xtemp.resize(n->nodevals->idx.size(), pXDlm);     Xtemp.setZero();  
     Ztemp.resize(n->nodevals->idx.size(), ctr->pZ);   Ztemp.setZero();  
@@ -1456,21 +1463,24 @@ treeMHR dlmtreeMixtures_MHR(std::vector<Node*> modTerm,
       j++;
     } // end loop over node indices
       
-    n->nodevals->XtX.resize(pXDlm, pXDlm);
-    n->nodevals->XtX = Xtemp.transpose() * Xtemp;
-    n->nodevals->ZtXmat.resize(ctr->pZ, pXDlm);
-    n->nodevals->ZtXmat = Ztemp.transpose() * Xtemp;
-    n->nodevals->VgZtXmat.resize(ctr->pZ, pXDlm);
-    n->nodevals->VgZtXmat = ctr->Vg * n->nodevals->ZtXmat;
-    n->nodevals->updateXmat = 0;
-    
+    if (n->nodevals->updateXmat) {
+      n->nodevals->XtX.resize(pXDlm, pXDlm);
+      n->nodevals->XtX = Xtemp.transpose() * Xtemp;
+      n->nodevals->ZtXmat.resize(ctr->pZ, pXDlm);
+      n->nodevals->ZtXmat = Ztemp.transpose() * Xtemp;
+      n->nodevals->VgZtXmat.resize(ctr->pZ, pXDlm);
+      n->nodevals->VgZtXmat = ctr->Vg * n->nodevals->ZtXmat;
+      n->nodevals->updateXmat = 0;
+    }
+
     XtR.segment(start, pXDlm) = Xtemp.transpose() * Rtemp;
-      
+
     // Update blocks
-    XtXblock.block(start, start, pXDlm, pXDlm) = ((n->nodevals->XtX) + LInv).inverse();
+    Eigen::MatrixXd blockMat = (n->nodevals->XtX) + LInv;
+    XtXblock.block(start, start, pXDlm, pXDlm) = blockMat.llt().solve(Eigen::MatrixXd::Identity(pXDlm, pXDlm));
     ZtX.block(0, start, ctr->pZ, pXDlm) = n->nodevals->ZtXmat;
     VgZtX.block(0, start, ctr->pZ, pXDlm) = n->nodevals->VgZtXmat;
-    
+
     // Move to the next block
     start += pXDlm;
   } // End of subsetting and building blocks
@@ -1479,8 +1489,10 @@ treeMHR dlmtreeMixtures_MHR(std::vector<Node*> modTerm,
   // Rcout << "pxMod != 1: VTheta / ThetaHat calculation \n";
   Eigen::MatrixXd ZtXXi = ZtX * XtXblock;
   Eigen::MatrixXd VTheta = XtXblock;
-  VTheta.noalias() += ZtXXi.transpose() * 
-    (ctr->VgInv - ZtXXi * ZtX.transpose()).inverse() * ZtXXi;
+
+  Eigen::MatrixXd innerMat = ctr->VgInv - ZtXXi * ZtX.transpose();
+  VTheta.noalias() += ZtXXi.transpose() * innerMat.llt().solve(ZtXXi);
+
   Eigen::VectorXd XtVzInvR = XtR;
   XtVzInvR.noalias() -= VgZtX.transpose() * ZtR;
   Eigen::VectorXd ThetaHat = VTheta * XtVzInvR;
@@ -1488,8 +1500,7 @@ treeMHR dlmtreeMixtures_MHR(std::vector<Node*> modTerm,
 
   // Store the sampled values and also add variance 
   out.drawAll = ThetaHat;
-  out.drawAll.noalias() += 
-      VThetaChol * as<Eigen::VectorXd>(rnorm(pXComb, 0.0, sqrt(ctr->sigma2)));
+  out.drawAll.noalias() += VThetaChol * as<Eigen::VectorXd>(rnorm(pXComb, 0.0, sqrt(ctr->sigma2)));
 
   // drawAll = mod1-dlm1 / mod1-dlm2 / mod1-dlm1&2 / mod2-dlm1 / mod2-dlm2 / mod2-dlm1&2 / mod3 ...
   // Fitted value & terminal effect draws
@@ -1507,7 +1518,7 @@ treeMHR dlmtreeMixtures_MHR(std::vector<Node*> modTerm,
   out.term1T2 = 0;
   out.term2T2 = 0;
   out.mixT2 = 0;
-  
+
   for (s = 0; s < modTerm.size(); s++) { 
     // Extract draws from the block matrix for each modifier terminal node
     drawTemp = out.drawAll.segment(s * pXDlm, pXDlm); 

--- a/src/dlmtreeMixtures.cpp
+++ b/src/dlmtreeMixtures.cpp
@@ -44,7 +44,7 @@ treeMHR dlmtreeMixtures_MHR(std::vector<Node*> modTerm,
 // [[Rcpp::export]]
 Rcpp::List dlmtreeMixtures(const Rcpp::List model){ 
   // *** Set up general control variables ***
-  dlmtreeCtr *ctr = new dlmtreeCtr;
+  dlmtreeCtr *ctr = new dlmtreeCtr();
 
   // MCMC parameters
   ctr->iter   = as<int>(model["nIter"]); 
@@ -194,7 +194,7 @@ Rcpp::List dlmtreeMixtures(const Rcpp::List model){
   // delete expNS;
 
   // *** Logs ***
-  dlmtreeLog *dgn = new dlmtreeLog;
+  dlmtreeLog *dgn = new dlmtreeLog();
   (dgn->gamma).resize(ctr->pZ, ctr->nRec);    (dgn->gamma).setZero();  
   (dgn->sigma2).resize(ctr->nRec);            (dgn->sigma2).setZero(); 
   (dgn->nu).resize(ctr->nRec);                (dgn->nu).setZero();     
@@ -484,16 +484,14 @@ Rcpp::List dlmtreeMixtures(const Rcpp::List model){
     // Progress mark
     prog->printMark();
   } // end MCMC
-  // Rcout << "MCMC complete \n";
 
+  prog->printMark(); 
 
   // *** Prepare outout ***
-  // Rcout << "Preparing output \n";
-  Eigen::MatrixXd TreeStructs((dgn->DLMexp).size(), 10);    
+  Eigen::MatrixXd TreeStructs((dgn->DLMexp).size(), 10);
   Rcpp::StringVector termRule(dgn->termRule.size());        
   Rcpp::StringVector termRuleMIX(dgn->termRuleMIX.size());  
 
-  // Store rec() vectors
   std::size_t s; 
   for (s = 0; s < (dgn->DLMexp).size(); s++){ 
     TreeStructs.row(s) = dgn->DLMexp[s];
@@ -563,10 +561,13 @@ Rcpp::List dlmtreeMixtures(const Rcpp::List model){
   delete prog;
   delete ctr;
   delete dgn;
+
   for (s = 0; s < Exp.size(); s++){       
     delete Exp[s];
   }
+
   delete Mod;
+
   for (s = 0; s < modTrees.size(); s++) { 
     delete modTrees[s];
     delete dlmTrees1[s];
@@ -595,8 +596,8 @@ Rcpp::List dlmtreeMixtures(const Rcpp::List model){
                             Named("modCount")       = wrap(modCount),
                             Named("modInf")         = wrap(modInf),
                             Named("treeDLMAccept")  = wrap(dlmAccept),
-                            Named("treeModAccept")  = wrap(modAccept)));
-                            //Named("fhat") = wrap(fhat),
+                            Named("treeModAccept")  = wrap(modAccept),
+                            Named("fhat") = wrap(fhat)));
                             //Named("totTerm") = wrap(totTerm),
                             //Named("expInf") = wrap(expInf),
                             //Named("mixInf") = wrap(mixInf),


### PR DESCRIPTION
### [Efficiency Improvement for Heterogeneity Models on Parsing Rules]

- Baseline
    - Each recorded term stores a text description of its modifier subgroup
    - The same description repeats once per exposure term
    - On completion, every stored entry was translated into readable form, redoing identical work each time

- Changed
    - Parse the distinct modifier rule once, match back to position
    - Translation logic remains untouched, applies to both hdlm and hdlmm

- Also (hdlmm only)
    - Skip recomputing per-node matrices when the existing staleness flag
      says nothing changed (about 25% of visits)
    - Two matrix inversions replaced with equivalent solves

**Benchmark result:** 
- Same seeds, 10 reps per configuration, each fit isolated, checked against simulation ground truth
- Mean (sd) of 10 runs, 20 trees / 1000 burn / 2000 iter.
 
```
model    scenario   n        before          after           ratio
hdlm     A          2000     22.8s (0.7)     17.9s (0.6)     1.27x
hdlm     A          5000     35.9s (1.0)     30.7s (1.0)     1.17x
hdlm     B          2000     24.2s (1.6)     19.1s (1.3)     1.27x
hdlm     B          5000     38.3s (1.4)     32.4s (1.3)     1.18x
hdlmm    D          2000     64.5s (4.3)     45.9s (2.4)     1.41x
hdlmm    D          5000     104.6s (8.3)    83.4s (5.5)     1.25x
hdlmm    D          10000    188.5s (15.3)   155.3s (11.0)   1.21x
hdlmm    E          2000     68.7s (4.8)     48.9s (2.2)     1.40x
hdlmm    E          5000     104.9s (4.3)    80.7s (5.3)     1.30x
```


### [Verified]

- Fixed-effect coefficients matches baseline
- Residual variance matches baseline run for run
- Interaction row counts: match baseline 
- HDLM subgroup descriptions: identical to baseline everywhere
- R CMD check: 0 errors, 0 warnings, 2 notes (both pre-existing)


### [Three Minor Bug Fixes for HDLMM]

- Summary showed a blank signal-to-noise figure:
    - The fitted exposure effect was never passed back from C++
    - Now included in the return value

- Short runs could fail outright:
    - With no interactions recorded (rarely), the interaction table came out one
      column short and stopped on a name mismatch
    - Empty case now handled

- Internal counters started with junk memory number:
    - Plain fields in the control and log structures were allocated without being zeroed, 
      so they held stale memory until first assignment
    - Now stabilized to initialize at zero